### PR TITLE
set rest v2 for connection

### DIFF
--- a/lib/jaspersoft/authentication.rb
+++ b/lib/jaspersoft/authentication.rb
@@ -1,7 +1,7 @@
 module Jaspersoft
   
   module Authentication
-    
+
     def basic_authenticated?
       !!(username && password)
     end
@@ -26,7 +26,7 @@ module Jaspersoft
     
     def authenticate_with_basic
       basic_agent = new_agent{ |http| http.basic_auth(username, password) }
-      response = basic_agent.call(:post, URI.encode("#{ endpoint_url(v2: false) }/login/".to_s), { content_type: "application/x-www-form-urlencoded", j_username: username, j_password: password })
+      response = basic_agent.call(:post, URI.encode("#{ endpoint_url }/login?j_username=#{username}&j_password=#{password}".to_s), { content_type: "application/x-www-form-urlencoded" })
 
       if response && response.status == 200 && response.headers["set-cookie"] != ""
         self.session = response.headers["set-cookie"].match(/jsessionid=(.+?);/i)[1]

--- a/lib/jaspersoft/configuration.rb
+++ b/lib/jaspersoft/configuration.rb
@@ -45,9 +45,8 @@ module Jaspersoft
       Hash[ * VALID_CONFIG_KEYS.map { |key| [key, send(key)] }.flatten ]
     end
     
-    def endpoint_url(options = {})
-      options = { v2: true }.merge(options)
-      "#{ endpoint }/jasperserver#{ enterprise_server ? "-pro" : "" }/rest#{ "_v2" if options[:v2] }"
+    def endpoint_url
+      "#{ endpoint }/jasperserver/rest_v2"
     end
     
   end


### PR DESCRIPTION
- we need to use the v2 rest protocol for the new server but the
code forces it to false
- we need to pass the auth with the url rather than the body; testing
with postman provided the response to why we originally couldn't
connect to the new server using the existing code
- given this is for our own use and we are not going backwards
there's no need to provide choices